### PR TITLE
Fixed makefile to fix compilation on MinGW.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,12 @@ CXXFLAGS+=`sdl-config --cflags`
 LDFLAGS+=`sdl-config --libs`
 
 # Enable modplug music
-CXXFLAGS += -DUSE_MODPLUG `pkg-config --cflags libmodplug`
-LDFLAGS += `pkg-config --libs libmodplug`
+#CXXFLAGS += -DUSE_MODPLUG `pkg-config --cflags libmodplug`
+#LDFLAGS += `pkg-config --libs libmodplug`
+
+# Enable XMP music
+CXXFLAGS += -DUSE_XMP `pkg-config --cflags libxmp`
+LDFLAGS += `pkg-config --libs libxmp`
 
 # Add for network support on windows
 LDFLAGS += -lws2_32

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,14 @@ LDFLAGS+=`sdl-config --libs`
 CXXFLAGS += -DUSE_MODPLUG `pkg-config --cflags libmodplug`
 LDFLAGS += `pkg-config --libs libmodplug`
 
+# Add for network support on windows
+LDFLAGS += -lws2_32
+
 OpenJazz: $(OBJS)
-	cc $(CXXFLAGS) -o OpenJazz $(LDFLAGS) -lstdc++ -lz $(OBJS)
+	g++ $(CXXFLAGS) -o OpenJazz $(OBJS) $(LDFLAGS) -lz
 
 %.o: %.cpp
-	cc $(CXXFLAGS) -Isrc -c $< -o $@
+	g++ $(CXXFLAGS) -Isrc -c $< -o $@
 
 clean:
 	rm -f OpenJazz $(OBJS)

--- a/README.md
+++ b/README.md
@@ -59,14 +59,19 @@ You will need the SDL 1.2.x library (https://libsdl.org/).
 
 For network play, you need a platform which provides sockets or use the SDL_net
 library (https://www.libsdl.org/projects/SDL_net/), then either define
-`USE_SOCKETS` or `USE_SDL_NET` in the Makefile.
+`USE_SOCKETS` or `USE_SDL_NET` in the Makefile. If using sockets on Windows,
+be sure to uncomment the line that adds "-lws2_32" in the makefile.
 
 For music support, you need to define `USE_MODPLUG` in the Makefile and the
 Modplug library (http://modplug-xmms.sourceforge.net/). The Modplug library
 needs to be patched to support looping tracks, otherwise half of the level will
 be silent.
 
-Further instructions are available at: http://www.alister.eu/jazz/oj/build.php
+Alternately to Modplug, you may use libxmp (https://sourceforge.net/projects/xmp/)
+for music support by defining `USE_XMP` in the Makefile. This does not need 
+patching for looping tracks.
+
+Further (outdated) instructions are available at: http://www.alister.eu/jazz/oj/build.php
 
 ### other options
 


### PR DESCRIPTION
Explanations: From what I've read, and what I've seen in most projects now, GCC needs the libraries to *follow* the objects these days. This fixed a bunch of "undefined reference" errors re: SDL and libz. In addition, using "cc" for a C++ project is wrong, it sets the wrong flags, and directly linking libstdc++ is unnecessary if you just use g++ instead.